### PR TITLE
Feature: optional availability zones

### DIFF
--- a/modules/aws-vpc/main.tf
+++ b/modules/aws-vpc/main.tf
@@ -37,21 +37,24 @@ resource "aws_subnet" "subnet" {
 
         # If vpc.subnets is == null, use coalesce with empty list
         for subnet in coalesce(vpc.subnets, []) : {
-          vpc_name        = vpc.name
-          subnet_name     = subnet.name
-          cidr_block      = subnet.cidr
-          create_network  = vpc.create_network
+          availability_zone = subnet.zone
+          cidr_block        = subnet.cidr
+          create_network    = vpc.create_network
+          subnet_name       = subnet.name
+          vpc_name          = vpc.name
         }
       ]
     ]) : "${subnet.vpc_name}-${subnet.subnet_name}" => {
-      cidr_block = subnet.cidr_block
-      vpc_id     = aws_vpc.vpc[subnet.vpc_name].id
-      name       = subnet.subnet_name
+      availability_zone = subnet.availability_zone
+      cidr_block        = subnet.cidr_block
+      name              = subnet.subnet_name
+      vpc_id            = aws_vpc.vpc[subnet.vpc_name].id
     } if subnet.create_network
   }
 
-  vpc_id     = each.value.vpc_id
-  cidr_block = each.value.cidr_block
+  availability_zone = each.value.availability_zone
+  cidr_block        = each.value.cidr_block
+  vpc_id            = each.value.vpc_id
 
   tags = {
     Name = each.value.name

--- a/modules/aws-vpc/variables.tf
+++ b/modules/aws-vpc/variables.tf
@@ -1,9 +1,3 @@
-# variable "aws_vpc" {
-#   description = "Controls if AWS Connectors are created"
-#   type        = bool
-#   default     = false
-# }
-
 variable "aws_vpc_data" {
   type = list(object({
 
@@ -25,6 +19,7 @@ variable "aws_vpc_data" {
       create_vm        = optional(bool, false)
       name             = string
       vm_type          = optional(string, "t2.nano")
+      zone             = optional(string)
     })))
 
   }))


### PR DESCRIPTION
## Overview
Allow availability zones to be passed in per-subnet as an optional attribute.

```hcl
 subnets            = optional(list(object({
      cidr             = string
      create_vm        = optional(bool, false)
      name             = string
      vm_type          = optional(string, "t2.nano")
      zone             = optional(string)
    })))
```